### PR TITLE
Add support for hCaptcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ A plugin which adds the [Google reCaptcha v2](https://developers.google.com/reca
 
 Additional options, configurable either through environment variable or by editing `config.py` in this repo.
 
-* CAPTCHA_ENABLED (default: True): Determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
-* CAPTCHA_PROVIDER (required): Configures which captcha provider to use. Options are reCaptcha and hCaptcha.
-* CAPTCHA_SECRET (required): The secret key provided to you by Google for reCaptcha.
-* CAPTCHA_SITE_KEY (required): The public site key provided to you by Google for reCaptcha.
-* CAPTCHA_INSERT_TAGS (default: True): Determines if the plugin should automatically attempt to insert tags (i.e. the script and check box). This works well if the registration template is not heavily modified, but set this to false if you want to control where the check box appears.
-* CAPTCHA_VERIFY_REMOTE_IP (default: False): Should be `True` if you want to include the client ip address in the verification step.
+* `CAPTCHA_ENABLED` (default: True): Determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
+* `CAPTCHA_PROVIDER` (required): Configures which captcha provider to use. Options are reCaptcha and hCaptcha.
+* `CAPTCHA_SECRET` (required): The secret key provided to you by Google for reCaptcha.
+* `CAPTCHA_SITE_KEY` (required): The public site key provided to you by Google for reCaptcha.
+* `CAPTCHA_INSERT_TAGS` (default: True): Determines if the plugin should automatically attempt to insert tags (i.e. the script and check box). This works well if the registration template is not heavily modified, but set this to false if you want to control where the check box appears.
+* `CAPTCHA_VERIFY_REMOTE_IP` (default: False): Should be `True` if you want to include the client ip address in the verification step.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
 # CTFd Captcha Plugin
 
-A plugin which adds the Google reCaptcha v2 backend code to the user registration function
+A plugin which adds the [Google reCaptcha v2](https://developers.google.com/recaptcha/docs/display) or [hCaptcha](https://www.hcaptcha.com/) checkbox to the registration page to prevent automated created of accounts on your CTF.
 
-1. Set up your account with Google reCaptcha [here](https://www.google.com/recaptcha/)
+> Note: Although Google reCaptcha has a longer track record of security, I personally recommend using hCaptcha for it's commitment to user privacy.
+
+### Setup
+
+1. Create an account with your captcha provider and add your site.
+  * [Google reCaptcha](https://www.google.com/recaptcha/admin): Create a v2 checkbox site and obtain the site key and sceret
+  * [hCaptcha](https://dashboard.hcaptcha.com/): Create a new site and obtain it's site key. Obtain the secret for your account.
 2. Clone this repo into a folder in the plugin folder of your CTFd
-3. Set the `CAPTCHA_SECRET` and `CAPTCHA_SITE_KEY` environment variables or edit the config.py file in this repo to include your reCaptcha keys
+3. Set the configuration variables either as environment variables or by editing `config.py` in this repo.
+  * Set `CAPTCHA_PROVIDER` to `reCaptcha` or `hCaptcha` depending on your preferences.
+  * Set `CAPTCHA_SECRET` and `CAPTCHA_SITE_KEY` your captcha keys.
+
+### Options
+
+Additional options, configurable either through environment variable or by editing `config.py` in this repo.
+
+* CAPTCHA_ENABLED (default: True): Determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
+* CAPTCHA_PROVIDER (required): Configures which captcha provider to use. Options are reCaptcha and hCaptcha.
+* CAPTCHA_SECRET (required): The secret key provided to you by Google for reCaptcha.
+* CAPTCHA_SITE_KEY (required): The public site key provided to you by Google for reCaptcha.
+* CAPTCHA_INSERT_TAGS (default: True): Determines if the plugin should automatically attempt to insert tags (i.e. the script and check box). This works well if the registration template is not heavily modified, but set this to false if you want to control where the check box appears.
+* CAPTCHA_VERIFY_REMOTE_IP (default: False): Should be `True` if you want to include the client ip address in the verification step.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# CTFd Google reCaptcha Plugin
+# CTFd Captcha Plugin
 
 A plugin which adds the Google reCaptcha v2 backend code to the user registration function
 
 1. Set up your account with Google reCaptcha [here](https://www.google.com/recaptcha/)
 2. Clone this repo into a folder in the plugin folder of your CTFd
-3. Set the `RECAPTCHA_SECRET` and `RECAPTCHA_SITE_KEY` environment variables or edit the config.py file in this repo to include your reCaptcha keys
+3. Set the `CAPTCHA_SECRET` and `CAPTCHA_SITE_KEY` environment variables or edit the config.py file in this repo to include your reCaptcha keys

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@ from os import environ
 from enum import Enum
 
 def envvar(key, default=None):
-    '''Return a variable from the environment, or the default. Inlcudes a check for deprecated RECAPTCHA_* keys.'''
+    '''Return a variable from the environment, or the default. Includes a check for deprecated RECAPTCHA_* keys for back compat.'''
     value = environ.get(key, None)
     if value is not None:
         return value
@@ -21,29 +21,29 @@ def config(app):
     '''
     CAPTCHA_ENABLED determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
     '''
-    app.config['CAPTCHA_ENABLED'] = environ.get('CAPTCHA_ENABLED', "True").lower() == 'true'
+    app.config['CAPTCHA_ENABLED'] = envvar('CAPTCHA_ENABLED', "True").lower() == 'true'
 
     '''
     CAPTCHA_SECRET is the secret key provided to you by Google for reCaptcha
     You may either set the CAPTCHA_SECRET env variable or save it here in this file
     '''
-    app.config['CAPTCHA_SECRET'] = environ.get('CAPTCHA_SECRET', 'INVALID_SECRET')
+    app.config['CAPTCHA_SECRET'] = envvar('CAPTCHA_SECRET', 'INVALID_SECRET')
 
     '''
     CAPTCHA_SITE_KEY is the public site key provided to you by Google for reCaptcha
     Needed if `CAPTCHA_INSERT_TAGS` is True
     You may either set the CAPTCHA_SITE_KEY env variable or save it here in this file
     '''
-    app.config['CAPTCHA_SITE_KEY'] = environ.get('CAPTCHA_SITE_KEY', 'INVALID_SITE_KEY')
+    app.config['CAPTCHA_SITE_KEY'] = envvar('CAPTCHA_SITE_KEY', 'INVALID_SITE_KEY')
 
     '''
     CAPTCHA_INSERT_TAGS determines if the plugin should automatically attempt to insert tags (i.e. the script and check box)
     This works well if the registration template is not heavily modified, but set this to false if you want to control where the
     check box appears
     '''
-    app.config['CAPTCHA_INSERT_TAGS'] = True
+    app.config['CAPTCHA_INSERT_TAGS'] = envvar('CAPTCHA_INSERT_TAGS', 'True').lower() == 'true'
 
     '''
     CAPTCHA_VERIFY_REMOTE_IP should be True if you want to include the client ip address in the verification step.
     '''
-    app.config['CAPTCHA_VERIFY_REMOTE_IP'] = False
+    app.config['CAPTCHA_VERIFY_REMOTE_IP'] = envvar('CAPTCHA_VERIFY_REMOTE_IP', 'False').lower() == 'true'

--- a/config.py
+++ b/config.py
@@ -1,38 +1,49 @@
 from os import environ
+from enum import Enum
 
-'''
-VERIFY_REMOTE_IP should be True if you want to include the client ip address in the verification step.
-'''
-VERIFY_REMOTE_IP = False
+def envvar(key, default=None):
+    '''Return a variable from the environment, or the default. Inlcudes a check for deprecated RECAPTCHA_* keys.'''
+    value = environ.get(key, None)
+    if value is not None:
+        return value
+
+    if key.startswith('CAPTCHA'):
+        return environ.get('RE' + key, default)
+
+    return default
 
 def config(app):
     '''
-    Determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
+    CAPTCHA_PROVIDER configures which captcha provider to use. Options are reCaptcha and hCaptcha.
     '''
-    app.config['RECAPTCHA_ENABLED'] = environ.get('RECAPTCHA_ENABLED', "True").lower() == 'true'
+    app.config['CAPTCHA_PROVIDER'] = environ.get('CAPTCHA_PROVIDER', None)
 
     '''
-    RECAPTCHA_SECRET is the secret key provided to you by Google for reCaptcha
-    You may either set the RECAPTCHA_SECRET env variable or save it here in this file
+    CAPTCHA_ENABLED determines whether or not to use the recaptcha feature. Set to False for debugging or otherwise turning off recaptcha.
     '''
-    app.config['RECAPTCHA_SECRET'] = environ.get('RECAPTCHA_SECRET', 'INVALID_SECRET')
+    app.config['CAPTCHA_ENABLED'] = environ.get('CAPTCHA_ENABLED', "True").lower() == 'true'
 
     '''
-    RECAPTCHA_SITE_KEY is the public site key provided to you by Google for reCaptcha
-    Needed if `RECAPTCHA_INSERT_TAGS` is True
-    You may either set the RECAPTCHA_SITE_KEY env variable or save it here in this file
+    CAPTCHA_SECRET is the secret key provided to you by Google for reCaptcha
+    You may either set the CAPTCHA_SECRET env variable or save it here in this file
     '''
-    app.config['RECAPTCHA_SITE_KEY'] = environ.get('RECAPTCHA_SITE_KEY', 'INVALID_SITE_KEY')
+    app.config['CAPTCHA_SECRET'] = environ.get('CAPTCHA_SECRET', 'INVALID_SECRET')
 
     '''
-    RECAPTCHA_INSERT_TAGS determines if the plugin should automatically attempt to insert tags (i.e. the script and check box)
+    CAPTCHA_SITE_KEY is the public site key provided to you by Google for reCaptcha
+    Needed if `CAPTCHA_INSERT_TAGS` is True
+    You may either set the CAPTCHA_SITE_KEY env variable or save it here in this file
+    '''
+    app.config['CAPTCHA_SITE_KEY'] = environ.get('CAPTCHA_SITE_KEY', 'INVALID_SITE_KEY')
+
+    '''
+    CAPTCHA_INSERT_TAGS determines if the plugin should automatically attempt to insert tags (i.e. the script and check box)
     This works well if the registration template is not heavily modified, but set this to false if you want to control where the
     check box appears
     '''
-    app.config['RECAPTCHA_INSERT_TAGS'] = True
+    app.config['CAPTCHA_INSERT_TAGS'] = True
 
-
-    if VERIFY_REMOTE_IP:
-        app.config['RECAPTCHA_VERIFY_URL'] = 'https://www.google.com/recaptcha/api/siteverify?secret={secret:s}&response={response:s}&remoteip={remoteip:s}'
-    else:
-        app.config['RECAPTCHA_VERIFY_URL'] = 'https://www.google.com/recaptcha/api/siteverify?secret={secret:s}&response={response:s}'
+    '''
+    CAPTCHA_VERIFY_REMOTE_IP should be True if you want to include the client ip address in the verification step.
+    '''
+    app.config['CAPTCHA_VERIFY_REMOTE_IP'] = False

--- a/providers.py
+++ b/providers.py
@@ -11,6 +11,16 @@ class VerificationError(Exception):
     '''Raised when verification could not be completed, such as when the provider returns an error.'''
 
 class CaptchaProvider(ABC):
+    @property
+    @abstractmethod
+    def verification_url(self):
+        pass
+
+    @property
+    @abstractmethod
+    def response_form_key(self):
+        pass
+
     @classmethod
     def parse(cls, string):
         if string is None:
@@ -19,7 +29,7 @@ class CaptchaProvider(ABC):
         if string.lower() in ['google', 'recaptcha', 're']:
             return ReCaptchaProvider
         if string.lower() in ['intuition machines', 'hcaptcha', 'h']:
-            raise NotImplementedError('hCatcha support is not yet implemented')
+            return HCaptchaProvider
 
         raise ValueError('{!r} could not be parsed as a captcha provider')
 
@@ -31,62 +41,113 @@ class CaptchaProvider(ABC):
     def challenge_tag(self):
         pass
 
-    @abstractmethod
-    def verify(self, form):
-        pass
+    def post_data(self, response, remote_ip=None):
+        data = {
+            'secret': self.secret,
+            'response': response,
+        }
 
-class ReCaptchaProvider(CaptchaProvider):
-    def __init__(self, secret, verify_remote_ip=False):
-        self.secret = secret
-        self.verify_remote_ip = verify_remote_ip
-
-    def script_tag(self):
-        raise NotImplementedError()
-
-    def challenge_tag(self):
-        raise NotImplementedError()
-
-    def verification_url(self, secret, response, remote_ip):
-        base = 'https://www.google.com/recaptcha/api/siteverify'
         if self.verify_remote_ip:
-            params = {
-                'secret': secret,
-                'response': response,
-                'remoteip': remote_ip,
-            }
-        else:
-            params = {
-                'secret': secret,
-                'response': response,
-            }
-        return '{:s}?{:s}'.format(base, urlencode(params))
+            if remote_ip is None:
+                logger.error("Configured to verify remote IP, but remote IP was not provided.")
+                raise VerificationError()
+            data['remoteip'] = remote_ip
+
+        return data
 
     def verify(self, form, remote_ip=None):
         # If the form did not include a captcha response, fail immediately.
-        if not form.get('g-recaptcha-response', None):
+        if not form.get(self.response_form_key, None):
             return False
 
-        # Construct and send a request to the captcha service.
-        request_url = self.verification_url(
-            secret = self.secret,
-            response = form['g-recaptcha-response'],
-            remote_ip = remote_ip
-        )
-        logger.debug("Sending reCaptcha verification request: {}".format(request_url))
-        verify_reponse = requests.post(request_url)
+        # Make the request to the captcha provider.
+        post_data = self.post_data(form[self.response_form_key], remote_ip)
+        logger.debug("Sending captcha verification request {} to {}".format(post_data, self.verification_url))
+        verify_reponse = requests.post(self.verification_url, data=post_data)
 
         # If the HTTP request failed, bail.
         try:
             verify_reponse.raise_for_status()
         except RequestException as e:
-            logger.error("Google reCaptcha request failed with code {}".format(verify_response.status_code))
+            logger.error("Captcha request failed with code {}".format(verify_response.status_code))
             raise VerificationError() from e
 
         # Parse the response and check for error codes.
         verify = verify_reponse.json()
-        logger.debug("Got reCaptcha response: {}".format(verify))
+        logger.debug("Got captcha verification response: {}".format(verify))
         if verify.get('error-codes', None):
-            logger.error("Google reCaptcha returned error codes {}".format(verify['error-codes']))
+            logger.error("Captcha service returned error codes {}".format(verify['error-codes']))
             raise VerificationError()
 
         return verify['success']
+
+class ReCaptchaProvider(CaptchaProvider):
+    verification_url = 'https://www.google.com/recaptcha/api/siteverify'
+    response_form_key = 'g-recaptcha-response'
+
+    def __init__(self, site_key, secret, verify_remote_ip=False):
+        self.site_key = site_key
+        self.secret = secret
+        self.verify_remote_ip = verify_remote_ip
+
+    def script_tag(self):
+        return etree.Element(
+            'script',
+            attrib = {
+                'src': 'https://www.google.com/recaptcha/api.js',
+                'async': 'true',
+                'defer': 'true'
+            }
+        )
+
+    def challenge_tag(self):
+        return etree.Element(
+            'div',
+            attrib = {
+                'class': 'g-recaptcha float-left',
+                'data-sitekey': self.site_key,
+            }
+        )
+
+class HCaptchaProvider(CaptchaProvider):
+    verification_url = 'https://hcaptcha.com/siteverify'
+    response_form_key = 'h-captcha-response'
+
+    def __init__(self, site_key, secret, verify_remote_ip=False):
+        self.site_key = site_key
+        self.secret = secret
+        self.verify_remote_ip = verify_remote_ip
+
+    def script_tag(self):
+        return etree.Element(
+            'script',
+            attrib = {
+                'src': 'https://hcaptcha.com/1/api.js',
+                'async': 'true',
+                'defer': 'true'
+            }
+        )
+
+    def challenge_tag(self):
+        return etree.Element(
+            'div',
+            attrib = {
+                'class': 'h-captcha float-left',
+                'data-sitekey': self.site_key,
+            }
+        )
+
+    def post_data(self, response, remote_ip=None):
+        data = {
+            'secret': self.secret,
+            'sitekey': self.site_key,
+            'response': response,
+        }
+
+        if self.verify_remote_ip:
+            if remote_ip is None:
+                logger.error("Configured to verify remote IP, but remote IP was not provided.")
+                raise VerificationError()
+            data['remoteip'] = remote_ip
+
+        return data

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,92 @@
+from abc import ABC, abstractmethod
+from lxml import etree
+from requests.exceptions import RequestException
+from urllib.parse import urlencode
+import logging
+import requests
+
+logger = logging.getLogger('captcha')
+
+class VerificationError(Exception):
+    '''Raised when verification could not be completed, such as when the provider returns an error.'''
+
+class CaptchaProvider(ABC):
+    @classmethod
+    def parse(cls, string):
+        if string is None:
+            raise ValueError('Captcha provider unspecified. Options include "Google" and "hCpatcha"')
+
+        if string.lower() in ['google', 'recaptcha', 're']:
+            return ReCaptchaProvider
+        if string.lower() in ['intuition machines', 'hcaptcha', 'h']:
+            raise NotImplementedError('hCatcha support is not yet implemented')
+
+        raise ValueError('{!r} could not be parsed as a captcha provider')
+
+    @abstractmethod
+    def script_tag(self):
+        pass
+
+    @abstractmethod
+    def challenge_tag(self):
+        pass
+
+    @abstractmethod
+    def verify(self, form):
+        pass
+
+class ReCaptchaProvider(CaptchaProvider):
+    def __init__(self, secret, verify_remote_ip=False):
+        self.secret = secret
+        self.verify_remote_ip = verify_remote_ip
+
+    def script_tag(self):
+        raise NotImplementedError()
+
+    def challenge_tag(self):
+        raise NotImplementedError()
+
+    def verification_url(self, secret, response, remote_ip):
+        base = 'https://www.google.com/recaptcha/api/siteverify'
+        if self.verify_remote_ip:
+            params = {
+                'secret': secret,
+                'response': response,
+                'remoteip': remote_ip,
+            }
+        else:
+            params = {
+                'secret': secret,
+                'response': response,
+            }
+        return '{:s}?{:s}'.format(base, urlencode(params))
+
+    def verify(self, form, remote_ip=None):
+        # If the form did not include a captcha response, fail immediately.
+        if not form.get('g-recaptcha-response', None):
+            return False
+
+        # Construct and send a request to the captcha service.
+        request_url = self.verification_url(
+            secret = self.secret,
+            response = form['g-recaptcha-response'],
+            remote_ip = remote_ip
+        )
+        logger.debug("Sending reCaptcha verification request: {}".format(request_url))
+        verify_reponse = requests.post(request_url)
+
+        # If the HTTP request failed, bail.
+        try:
+            verify_reponse.raise_for_status()
+        except RequestException as e:
+            logger.error("Google reCaptcha request failed with code {}".format(verify_response.status_code))
+            raise VerificationError() from e
+
+        # Parse the response and check for error codes.
+        verify = verify_reponse.json()
+        logger.debug("Got reCaptcha response: {}".format(verify))
+        if verify.get('error-codes', None):
+            logger.error("Google reCaptcha returned error codes {}".format(verify['error-codes']))
+            raise VerificationError()
+
+        return verify['success']

--- a/recaptcha.py
+++ b/recaptcha.py
@@ -1,4 +1,5 @@
 from .config import config
+from .providers import VerificationError, CaptchaProvider
 from flask import request, render_template
 from functools import wraps
 from lxml import etree
@@ -7,12 +8,12 @@ import logging
 import os
 import requests
 
-logger = logging.getLogger('naumachia')
+logger = logging.getLogger('captcha')
 
 def load(app):
     config(app)
 
-    if not app.config['RECAPTCHA_ENABLED']:
+    if not app.config['CAPTCHA_ENABLED']:
         return
 
     # Intitialize logging.
@@ -30,6 +31,8 @@ def load(app):
     handler = logging.handlers.RotatingFileHandler(log_file, maxBytes=10000)
     logger.addHandler(handler)
     logger.propagate = 0
+
+    provider = CaptchaProvider.parse(app.config['CAPTCHA_PROVIDER'])(app.config['CAPTCHA_SECRET'], app.config['CAPTCHA_VERIFY_REMOTE_IP'])
 
     def insert_tags(page):
         if isinstance(page, etree._ElementTree):
@@ -52,7 +55,7 @@ def load(app):
                     etree.Element('div',
                         attrib = {
                             'class': 'g-recaptcha float-left',
-                            'data-sitekey': app.config['RECAPTCHA_SITE_KEY']
+                            'data-sitekey': app.config['CAPTCHA_SITE_KEY']
                         }
                     )
                 )
@@ -75,6 +78,7 @@ def load(app):
 
         return etree.tostring(root, method='html')
 
+    # Attempt to add an LRU cache to the insert function. If not available in the current runtime, continue.
     try:
         from functools import lru_cache
         insert_tags = lru_cache(maxsize=8)(insert_tags)
@@ -93,48 +97,28 @@ def load(app):
         def wrapper(*args, **kwargs):
             if request.method == 'POST':
                 errors = []
-                bad_request = False
-                if 'g-recaptcha-response' in request.form and request.form['g-recaptcha-response']:
-                    params = {
-                        'secret': app.config['RECAPTCHA_SECRET'],
-                        'response': request.form['g-recaptcha-response'],
-                        'remoteip':  request.remote_addr
-                    }
-                    request_url = app.config['RECAPTCHA_VERIFY_URL'].format(**params)
-                    verify_reponse = requests.post(request_url)
-                    logger.debug("Sending reCaptcha verification request: {}".format(request_url))
+                verified = None
+                try:
+                    verified = provider.verify(request.form, request.remote_addr)
+                except VerificationError as e:
+                    errors.append("Captcha service is currently unavailable. Please try again later")
 
-                    if verify_reponse.ok:
-                        verify =  json.loads(verify_reponse.text)
-                        logger.debug("Got reCaptcha response: {}".format(verify))
-                        if 'error-codes' in verify and verify['error-codes']:
-                            bad_request = True
-                            logger.error("Google reCaptcha returned error codes {}".format(verify['error-codes']))
-                        elif verify['success']:
-                            logger.debug("{} is human".format(request.form['name']))
-                            return register_func(*args, **kwargs)
-                    else:
-                        bad_request = True
-                        logger.error("Google reCaptcha request failed with code {}".format(verify_response.status_code))
+                if verified is False:
+                    errors.append("Please check the captcha box to verify you are human")
 
-                if bad_request:
-                    errors.append("Google reCaptcha is currently unavailable. Please try again later")
-                else:
-                    errors.append("Please check the reCaptcha box to verify you are human")
-
-                return render_template(
-                    'register.html',
-                    errors=errors,
-                    name=request.form['name'],
-                    email=request.form['email'],
-                    password=request.form['password']
-                )
-            else:
-                return register_func(*args, **kwargs)
+                if not verified:
+                    return render_template(
+                        'register.html',
+                        errors=errors,
+                        name=request.form['name'],
+                        email=request.form['email'],
+                        password=request.form['password']
+                    )
+            return register_func(*args, **kwargs)
 
         return wrapper
 
     app.view_functions['auth.register'] = register_decorator(app.view_functions['auth.register'])
 
-    if app.config['RECAPTCHA_INSERT_TAGS']:
+    if app.config['CAPTCHA_INSERT_TAGS']:
         app.view_functions['auth.register'] = insert_tags_decorator(app.view_functions['auth.register'])


### PR DESCRIPTION
This PR adds support for [hCaptcha](https://www.hcaptcha.com/), a relatively new alternative to Google reCaptcha, with a stronger commitment to privacy. 

reCaptcha has always raised privacy concerns, but given it was by far the best option in terms of user experience and security, this plugin was created to use it for CTFd. Recently however, hCaptcha has provided a compelling alternative. [Cloudflare recently switched to hCaptcha](https://www.pcmag.com/news/cloudflare-dumps-googles-recaptcha-over-privacy-concerns-costs) for all of it's sites.

This PR adds support for hCaptcha while maintaining existing support for Google reCaptcha. New users will be recommended to choose hCaptcha.